### PR TITLE
add polaris algorithm results demo

### DIFF
--- a/catalogs/cerulean.yaml
+++ b/catalogs/cerulean.yaml
@@ -48,3 +48,4 @@ collections:
   - ARCTIC_ANALYSISFORECAST_PHY_ICE_002_011_sisnthick
   - ARCTIC_ANALYSISFORECAST_PHY_ICE_002_011_sithick
   - ARCTIC_ANALYSISFORECAST_PHY_ICE_002_011_vsi_vector
+  - Polaris_algorithm_dmi_demo

--- a/collections/Polaris_algorithm_dmi_demo.yaml
+++ b/collections/Polaris_algorithm_dmi_demo.yaml
@@ -1,0 +1,57 @@
+Name: Polaris_algorithm_dmi_demo
+Title: Polaris Results demo
+EodashIdentifier: Polaris_algorithm_dmi_demo
+Description: ''
+CollectionGroup: 'Polaris sample results'
+Themes:
+  - cryosphere
+Agency:
+  - DMI
+# Legend: Polartep_SeaIceCharts_demo/legend.png
+# Image: Polartep_SeaIceCharts_demo/thumbnail.png
+Resources:
+  - Name: GeoJSON source
+    Style: Polaris_algorithm_dmi_demo/style.json
+    Bbox: [-50, 59, -39, 65]
+    TimeEntries:
+      - Time: "20240831"
+        Assets:
+          - Identifier: "Polaris Results 20240831 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202408312025_CapeFarewell_RIC-processed.geojson
+      - Time: "20240903"
+        Assets:
+          - Identifier: "Polaris Results 20240903 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409030910_CapeFarewell_RIC-processed.geojson
+      - Time: "20240906"
+        Assets:
+          - Identifier: "Polaris Results 20240906 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409060930_CapeFarewell_RIC-processed.geojson
+      - Time: "20240907"
+        Assets:
+          - Identifier: "Polaris Results 20240907 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409072035_CapeFarewell_RIC-processed.geojson
+      - Time: "20240909"
+        Assets:
+          - Identifier: "Polaris Results 20240909 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409092020_CapeFarewell_RIC-processed.geojson
+      - Time: "20240913"
+        Assets:
+          - Identifier: "Polaris Results 20240913 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409130925_CapeFarewell_RIC-processed.geojson
+      - Time: "20240914"
+        Assets:
+          - Identifier: "Polaris Results 20240914 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409140915_CapeFarewell_RIC-processed.geojson
+      - Time: "20240917"
+        Assets:
+          - Identifier: "Polaris Results 20240917 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409172100_CapeFarewell_RIC-processed.geojson
+      - Time: "20240921"
+        Assets:
+          - Identifier: "Polaris Results 20240921 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409212030_CapeFarewell_RIC-processed.geojson
+      - Time: "20240923"
+        Assets:
+          - Identifier: "Polaris Results 20240923 Cape Farewell"
+            File: https://eox-gtif-public.s3.eu-central-1.amazonaws.com/test_data_polartep/dmi_icecharts_geojson/202409232040_CapeFarewell_RIC-processed.geojson
+


### PR DESCRIPTION
Add preselected and precomputed Polaris results demo from gtif-public bucket for now.

[Referenced style](https://github.com/gtif-cerulean/assets/commit/a253a1df3a20f4db4cd0923bed706b5694ca1aa0) contains visualisation for POLARIS and Sea Ice Concentration.

Polaris style could be drastically simplified if https://github.com/EOX-A/EOxElements/issues/626 is added to jsonform allowing to combine 2 dropdown keys - `ship_class` and `ice_type` to combine into one final variable name to get property from geojson.

In current demo anyway values for all columns look to be exactly the same for a single polygon (all types of ships and both types of ice have the same value). `concat` from [Openlayers style expressions](https://openlayers.org/en/latest/examples/style-expressions.html) can not be used for this purpose, as it is an `expression` that gets evaluated after `get`.  Asked @peanutbutter-memory  for clarification. 

Missing todo is State of Development, which seems to have values ("Bergy Water") in the referenced GeoJSON files not corresponding to the via-email provided legend. @peanutbutter-memory could you clarify if is as expected please?

Implementation-wise style will be a copy of Sea Ice Concentration match -> value.

Another missing todo is IRSS GO-NOGO visualisation which will be the same principle as Polaris style.